### PR TITLE
Fixed tailwind config, add path for lib/components

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ module.exports = {
   content: [
     './app/**/*.{js,ts,jsx,tsx}',
     './pages/**/*.{js,ts,jsx,tsx}',
-    './components/**/*.{js,ts,jsx,tsx}',
+    './lib/components/**/*.{js,ts,jsx,tsx}',
 
     // Or if using `src` directory:
     './src/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
Quick fix for tailwind not registering changes in components folder, see issue #24 Tailwind config file fix.