### PR TITLE
Update tsconfig in packages/client

### DIFF
--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -5,19 +5,21 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
-    "strictNullChecks": false, // TODO make "true" once all files are converted to TS
-    "noImplicitAny": false, // TODO: make "true" once all files are converted to TS
     "isolatedModules": true,
     "jsx": "preserve",
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmit": true,
+    "noImplicitAny": false, // TODO: make "true" once all files are converted to TS
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strict": true,
-    "target": "es5",
     "sourceMap": true,
+    "strict": true,
+    "strictNullChecks": false, // TODO make "true" once all files are converted to TS
+    "target": "es5",
     "paths": {
       "@/*": ["./*"]
     }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,11 +1,12 @@
 {
   "compilerOptions": {
-    "allowJs": true, // TODO: turn off once all files are converted to TS
+    "allowJs": true, // TODO: make "false" once all files are converted to TS
     "checkJs": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
-    "noImplicitAny": false, // TODO: turn off once all files are converted to TS
+    "strictNullChecks": false, // TODO make "true" once all files are converted to TS
+    "noImplicitAny": false, // TODO: make "true" once all files are converted to TS
     "isolatedModules": true,
     "jsx": "preserve",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,20 +1,21 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
+    "allowJs": true, // TODO: turn off once all files are converted to TS
     "checkJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "incremental": true,
+    "noImplicitAny": false, // TODO: turn off once all files are converted to TS
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es5",
     "paths": {
       "@/*": ["./*"]
     }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -17,6 +17,7 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "es5",
+    "sourceMap": true,
     "paths": {
       "@/*": ["./*"]
     }


### PR DESCRIPTION
Turns off `noImplicitAny` & `strictNullChecks` in the `packages/client/tsconfig.json`. Hopefully, this will reduce or eliminate all the TS linting errors in `js/jsx` files which are not helpful for those that are not familiar with TypeScript.

I've left `checkJs` on as this provides some additional helpful static type-checking but hopefully without unhelpful TS linting errors. Turned on `sourceMaps` as that can be helpful for attaching a debugger and stepping through code.

References https://github.com/TeamPetPoison/pet-poison-alert/issues/41